### PR TITLE
Patch the returned certificate_file may be False

### DIFF
--- a/custom_components/vimar/vimarlink/vimarlink.py
+++ b/custom_components/vimar/vimarlink/vimarlink.py
@@ -109,7 +109,7 @@ class VimarLink:
             downloadPath = "%s://%s:%s/vimarbyweb/modules/vimar-byme/script/rootCA.VIMAR.crt" % (VimarLink._schema, VimarLink._host, VimarLink._port)
             certificate_file = self._request(downloadPath)
 
-            if certificate_file is None:
+            if certificate_file is None or certificate_file == False:
                 raise VimarConnectionError("Certificate download failed")
 
             # get it back


### PR DESCRIPTION
In the function VimarLink._request, the function can return either None or False in the case of an error, so therefore include checking for the False state in the case of a request exception when checking that certificate_file is None