### PR TITLE
Patch a double if statement and patch auto detection for climate

### DIFF
--- a/custom_components/vimar/climate.py
+++ b/custom_components/vimar/climate.py
@@ -158,9 +158,15 @@ class VimarClimate(VimarEntity, ClimateEntity):
             return HVAC_MODE_OFF
 
         if self.climate_type == "heat_cool":
-            return (HVAC_MODE_HEAT, HVAC_MODE_COOL)[self.get_state("stagione") == self.get_const_value(VIMAR_CLIMATE_COOL)]
+            if self.get_const_value(VIMAR_CLIMATE_AUTO) == self.get_state("funzionamento"):
+                return HVAC_MODE_AUTO
+            else:
+                return (HVAC_MODE_HEAT, HVAC_MODE_COOL)[self.get_state("stagione") == self.get_const_value(VIMAR_CLIMATE_COOL)]
         else:
-            return (HVAC_MODE_HEAT, HVAC_MODE_COOL)[self.get_state("regolazione") == self.get_const_value(VIMAR_CLIMATE_COOL)]
+            if self.get_const_value(VIMAR_CLIMATE_AUTO) == self.get_state("funzionamento"):
+                return HVAC_MODE_AUTO
+            else:
+                return (HVAC_MODE_HEAT, HVAC_MODE_COOL)[self.get_state("regolazione") == self.get_const_value(VIMAR_CLIMATE_COOL)]
 
             # if self.has_state('stato_principale_condizionamento on/off') and self.get_state('stato_principale_condizionamento on/off') == '1':
             #     return HVAC_MODE_COOL
@@ -380,8 +386,6 @@ class VimarClimate(VimarEntity, ClimateEntity):
                 return VIMAR_CLIMATE_COOL_I
             elif const == VIMAR_CLIMATE_HEAT:
                 return VIMAR_CLIMATE_HEAT_I
-            elif const == VIMAR_CLIMATE_HEAT:
-                return VIMAR_CLIMATE_HEAT_I
             else:
                 return None
         else:
@@ -393,8 +397,6 @@ class VimarClimate(VimarEntity, ClimateEntity):
                 return VIMAR_CLIMATE_AUTO_II
             elif const == VIMAR_CLIMATE_COOL:
                 return VIMAR_CLIMATE_COOL_II
-            elif const == VIMAR_CLIMATE_HEAT:
-                return VIMAR_CLIMATE_HEAT_II
             elif const == VIMAR_CLIMATE_HEAT:
                 return VIMAR_CLIMATE_HEAT_II
             else:


### PR DESCRIPTION
Patch a useless double if statement found in climate.py. And add functionality for auto, I noticed in the comment you (h4de5) wrote that it's impossible to return auto, I digress, since the property hvac_action is there for that reason. Unless I misunderstood, either way, it works pretty well on my home system.

Also, I would be interested in talking to you, @h4de5 as I wanted to discuss your findings on the domotic system vimar, if you're interested to talk, then you can email me at robigan@robigan.com or on discord, robigan#1634